### PR TITLE
feat: enable Russian OCR in PaddleX config

### DIFF
--- a/paddlex/ocr_config.yml
+++ b/paddlex/ocr_config.yml
@@ -180,7 +180,7 @@ SubPipelines:
         SubModules:
           TextDetection:
             module_name: text_detection
-            model_name: PP-OCRv4_server_det
+            model_name: PP-OCRv5_server_det
             model_dir: null
             limit_side_len: 960
             limit_type: max
@@ -190,12 +190,12 @@ SubPipelines:
             unclip_ratio: 1.5
           TextLineOrientation:
             module_name: textline_orientation
-            model_name: PP-LCNet_x1_0_textline_ori 
+            model_name: PP-LCNet_x1_0_textline_ori
             model_dir: null
-            batch_size: 6   
+            batch_size: 6
           TextRecognition:
             module_name: text_recognition
-            model_name: PP-OCRv4_server_rec_doc
+            model_name: eslav_PP-OCRv5_mobile_rec
             model_dir: null
             batch_size: 6
             score_thresh: 0.0


### PR DESCRIPTION
## Summary
- switch OCR detection to PP-OCRv5
- use East Slavic recognition model to support Russian text

## Testing
- `docker compose run paddleocr` *(fails: docker: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b570ba7fc083208b788089ebe3b97f