### PR TITLE
feat: add table structure module to OCR config

### DIFF
--- a/paddlex/ocr_config.yml
+++ b/paddlex/ocr_config.yml
@@ -23,3 +23,8 @@ SubModules:
     model_name: eslav_PP-OCRv5_mobile_rec
     model_dir: null
     batch_size: 6
+  TableStructure:
+    module_name: table_structure
+    model_name: PP-StructureV2
+    model_dir: null
+    output_format: table


### PR DESCRIPTION
## Summary
- add TableStructure module using PP-StructureV2 to enable table recognition
- include output_format option for table or html rendering

## Testing
- `python - <<'PY'
import yaml
with open('paddlex/ocr_config.yml') as f:
    data = yaml.safe_load(f)
print(list(data.keys()))
print(list(data['SubModules'].keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b5a73a2bd48320be6ec15ddfaf3dd4