### PR TITLE
fix: set supported PaddleX OCR models

### DIFF
--- a/paddlex/ocr_config.yml
+++ b/paddlex/ocr_config.yml
@@ -8,7 +8,7 @@ DocPreprocessor:
 SubModules:
   TextDetection:
     module_name: text_detection
-    model_name: PP-OCRv5_server_det
+    model_name: PP-OCRv4_server_det
     model_dir: null
     limit_side_len: 960
     limit_type: max
@@ -23,7 +23,7 @@ SubModules:
     batch_size: 2
   TextRecognition:
     module_name: text_recognition
-    model_name: eslav_PP-OCRv5_mobile_rec
+    model_name: eslav_PP-OCRv4_rec
     model_dir: null
     batch_size: 2
   TableStructure:


### PR DESCRIPTION
## Summary
- use PP-OCRv4_server_det for text detection
- switch text recognition model to eslav_PP-OCRv4_rec

## Testing
- `docker compose logs paddleocr` *(fails: docker: 'compose' is not a docker command.)*
- `docker-compose up -d paddleocr` *(fails: invalid interpolation format for env in service n8n-import)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c4a30614832097c017bfe9fc75ee